### PR TITLE
Fixed: bad args for AssetDatabase.FindAssets

### DIFF
--- a/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/AppleCoreBuildStep.cs
+++ b/plug-ins/Apple.Core/Apple.Core_Unity/Assets/Apple.Core/Editor/AppleCoreBuildStep.cs
@@ -13,13 +13,6 @@ namespace Apple.Core
     {
         public override string DisplayName => "Apple.Core";
 
-        readonly Dictionary<BuildTarget, string> _libraryTable = new Dictionary<BuildTarget, string>
-        {
-            {BuildTarget.iOS, "AppleCoreNative.framework"},
-            {BuildTarget.tvOS, "AppleCoreNative.framework"},
-            {BuildTarget.StandaloneOSX, "AppleCoreNativeMac.bundle"}
-        };
-
 #if UNITY_EDITOR_OSX
         public override void OnFinalizePostProcess(AppleBuildProfile appleBuildProfile, BuildTarget buildTarget, string pathToBuiltProject)
         {
@@ -42,9 +35,9 @@ namespace Apple.Core
 
         public override void OnProcessFrameworks(AppleBuildProfile _, BuildTarget buildTarget, string pathToBuiltTarget, PBXProject pbxProject)
         {
-            if (_libraryTable.ContainsKey(buildTarget))
+            if (buildTarget == BuildTarget.iOS || buildTarget == BuildTarget.tvOS || buildTarget == BuildTarget.StandaloneOSX)
             {
-                string libraryName = _libraryTable[buildTarget];
+                string libraryName = buildTarget == BuildTarget.StandaloneOSX ? "AppleCoreNativeMac" : "AppleCoreNative";
                 string libraryPath = AppleFrameworkUtility.GetPluginLibraryPathForBuildTarget(libraryName, buildTarget);
                 if (string.IsNullOrEmpty(libraryPath))
                 {

--- a/plug-ins/Apple.GameController/Apple.GameController_Unity/Assets/Apple.GameController/Editor/AppleGameControllerBuildStep.cs
+++ b/plug-ins/Apple.GameController/Apple.GameController_Unity/Assets/Apple.GameController/Editor/AppleGameControllerBuildStep.cs
@@ -14,13 +14,6 @@ namespace Apple.GameController.Editor
     {
         public override string DisplayName => "GameController";
 
-        readonly Dictionary<BuildTarget, string> _libraryTable = new Dictionary<BuildTarget, string>
-        {
-            {BuildTarget.iOS, "GameControllerWrapper.framework"},
-            {BuildTarget.tvOS, "GameControllerWrapper.framework"},
-            {BuildTarget.StandaloneOSX, "GameControllerWrapper.bundle"}
-        };
-
         public bool GCSupportsControllerUserInteraction = true;
         public bool SupportsMicroGamePad = true;
         public bool SupportsExtendedGamePad = true;
@@ -65,9 +58,9 @@ namespace Apple.GameController.Editor
 
         public override void OnProcessFrameworks(AppleBuildProfile _, BuildTarget buildTarget, string pathToBuiltTarget, PBXProject pbxProject)
         {
-            if (_libraryTable.ContainsKey(buildTarget))
+            if (buildTarget == BuildTarget.iOS || buildTarget == BuildTarget.tvOS || buildTarget == BuildTarget.StandaloneOSX)
             {
-                string libraryName = _libraryTable[buildTarget];
+                const string libraryName = "GameControllerWrapper";
                 string libraryPath = AppleFrameworkUtility.GetPluginLibraryPathForBuildTarget(libraryName, buildTarget);
                 if (String.IsNullOrEmpty(libraryPath))
                 {

--- a/plug-ins/Apple.GameKit/Apple.GameKit_Unity/Assets/Apple.GameKit/Editor/AppleGameKitBuildStep.cs
+++ b/plug-ins/Apple.GameKit/Apple.GameKit_Unity/Assets/Apple.GameKit/Editor/AppleGameKitBuildStep.cs
@@ -14,13 +14,6 @@ namespace Apple.GameKit.Editor
     {
         public override string DisplayName => "GameKit";
 
-        readonly Dictionary<BuildTarget, string> _libraryTable = new Dictionary<BuildTarget, string>
-        {
-            {BuildTarget.iOS, "GameKitWrapper.framework"},
-            {BuildTarget.tvOS, "GameKitWrapper.framework"},
-            {BuildTarget.StandaloneOSX, "GameKitWrapper.bundle"}
-        };
-
 #if UNITY_EDITOR_OSX
         public override void OnProcessEntitlements(AppleBuildProfile _, BuildTarget buildTarget, string _1, PlistDocument entitlements)
         {
@@ -32,9 +25,9 @@ namespace Apple.GameKit.Editor
 
         public override void OnProcessFrameworks(AppleBuildProfile _, BuildTarget buildTarget, string pathToBuiltTarget, PBXProject pbxProject)
         {
-            if (_libraryTable.ContainsKey(buildTarget))
+            if (buildTarget == BuildTarget.iOS || buildTarget == BuildTarget.tvOS || buildTarget == BuildTarget.StandaloneOSX)
             {
-                string libraryName = _libraryTable[buildTarget];
+                const string libraryName = "GameKitWrapper";
                 string libraryPath = AppleFrameworkUtility.GetPluginLibraryPathForBuildTarget(libraryName, buildTarget);
                 if (String.IsNullOrEmpty(libraryPath))
                 {


### PR DESCRIPTION
When AppleFrameworkUtility.GetPluginLibraryPathForBuildTarget() is being called, the libraryName arguments are coming in with extensions. This causes the .bundle/.framework files to not be found during the post-build process.